### PR TITLE
Conda package recipes for Shumlib, Mule, and ANTS

### DIFF
--- a/conda/mo_ants/meta.yaml
+++ b/conda/mo_ants/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: "{{ version }}"
 
 source:
-  svn_url: <Insert MOSRS svn url>/ancil/ants/tags/{{ version }}
+  svn_url: {{ environ.get('NGMOENVS_MOSRS_MIRROR', 'https://code.metoffice.gov.uk/svn') }}/ancil/ants/tags/{{ version }}
   svn_rev: "{{ revision }}"
 
 build:

--- a/conda/mo_ants/meta.yaml
+++ b/conda/mo_ants/meta.yaml
@@ -1,0 +1,89 @@
+{% set name = "mo_ants" %}
+{% set version = "2.0.0" %}
+{% set revision = "HEAD" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  svn_url: <Insert MOSRS svn url>/ancil/ants/tags/{{ version }}
+  svn_rev: "{{ revision }}"
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python=3.10.13
+    - pip
+    - iris=3.7.1
+    - mule=2023.08.1
+    - numba
+    - pykdtree
+    - gdal
+    - python-stratify
+    - black
+    - cftime
+    - dask=2023.11.0
+    - esmf
+    - esmpy
+    - f90nml
+    - filelock
+    - flake8
+    - isort
+    - mo_pack
+    - numpy=1.26.0
+    - pre-commit
+    - pyflakes
+    - mpi=*=openmpi
+  run:
+    - python=3.10.13
+    - pip
+    - iris=3.7.1
+    - mule=2023.08.1
+    - numba
+    - pykdtree
+    - gdal
+    - python-stratify
+    - black
+    - cftime
+    - dask=2023.11.0
+    - esmf
+    - esmpy
+    - f90nml
+    - filelock
+    - flake8
+    - isort
+    - mo_pack
+    - numpy=1.26.0
+    - pre-commit
+    - pyflakes
+    - mpi=*=openmpi
+
+test:
+  imports:
+    - ants
+  source_files:
+    - KGO
+    - rose-stem/sources
+    - lib/ants/tests/resources
+  requires:
+    - pytest
+  commands:
+    - ancil_2anc.py -h
+    - ancil_create_shapefile.py -h
+    - ancil_fill_n_merge.py -h
+    - ancil_general_regrid.py -h
+    - ants-version
+    - cd $(dirname $(python -c 'import ants; print(ants.__file__)'))
+    - ln -s ${SRC_DIR}/KGO .
+    - ln -s ${SRC_DIR}/rose-stem/sources .
+    - ln -s ${SRC_DIR}/lib/ants/tests/resources tests/resources
+    - python -m pytest --continue-on-collection-errors . || true # ignore fails
+
+about:
+  home: https://code.metoffice.gov.uk/doc/ancil/ants/latest/index.html
+  license: BSD
+  license_family: BSD
+  summary: ANTS is a versatile Python library for developing ancillary applications.

--- a/conda/mule/build.sh
+++ b/conda/mule/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -ex
+
+${PYTHON} -m pip install -vv --no-deps --no-build-isolation ./um_spiral_search
+${PYTHON} -m pip install -vv --no-deps --no-build-isolation ./um_packing
+${PYTHON} -m pip install -vv --no-deps --no-build-isolation ./mule
+${PYTHON} -m pip install -vv --no-deps --no-build-isolation ./um_ppibm
+${PYTHON} -m pip install -vv --no-deps --no-build-isolation ./um_utils

--- a/conda/mule/meta.yaml
+++ b/conda/mule/meta.yaml
@@ -11,7 +11,7 @@ package:
   version: "{{ version }}"
 
 source:
-  svn_url: <Insert MOSRS svn url>/um/mule/trunk
+  svn_url: {{ environ.get('NGMOENVS_MOSRS_MIRROR', 'https://code.metoffice.gov.uk/svn') }}/um/mule/trunk
   svn_rev: "{{ revision }}"
   patches:
     - um_ppibm_setup.patch

--- a/conda/mule/meta.yaml
+++ b/conda/mule/meta.yaml
@@ -1,0 +1,146 @@
+{% set name = "mule" %}
+{% set version = "2023.08.1" %}
+{% set revision = "119685" %}
+
+# Need to fix these versions for compatibility with ANTS
+{% set py_version = "3.10" %}
+{% set numpy_version = "1.26.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  svn_url: <Insert MOSRS svn url>/um/mule/trunk
+  svn_rev: "{{ revision }}"
+  patches:
+    - um_ppibm_setup.patch
+    - um_utils_select_exit_code.patch
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - python={{ py_version }}
+    - pip
+    - numpy={{ numpy_version }}
+    - six
+    - pillow
+    - shumlib
+
+outputs:
+  - name: mule-um-spiral-search
+    files:
+      - lib/python{{ py_version }}/site-packages/um_spiral_search
+      - lib/python{{ py_version }}/site-packages/um_spiral_search-{{ version|replace(".0", ".") }}.dist-info
+    requirements:
+      run:
+        - python={{ py_version }}
+        - numpy={{ numpy_version }}
+        - shumlib
+    test:
+      imports:
+        - um_spiral_search
+      commands:
+        - python -m unittest discover -vs ${SP_DIR}/um_spiral_search/tests
+
+  - name: mule-um-packing
+    files:
+      - lib/python{{ py_version }}/site-packages/um_packing
+      - lib/python{{ py_version }}/site-packages/um_packing-{{ version|replace(".0", ".") }}.dist-info
+    requirements:
+      run:
+        - python={{ py_version }}
+        - numpy={{ numpy_version }}
+        - six
+        - shumlib
+    test:
+      imports:
+        - um_packing
+      commands:
+        - python -m unittest discover -vs ${SP_DIR}/um_packing/tests
+
+  - name: mule-base
+    files:
+      - lib/python{{ py_version }}/site-packages/mule
+      - lib/python{{ py_version }}/site-packages/mule-{{ version|replace(".0", ".") }}.dist-info
+    requirements:
+      run:
+        - python={{ py_version }}
+        - numpy={{ numpy_version }}
+        - six
+        - {{ pin_subpackage('mule-um-packing', exact=True) }}
+    test:
+      imports:
+        - mule
+      commands:
+        - python -m unittest discover -vs ${SP_DIR}/mule/tests
+
+  - name: mule-um-ppibm
+    files:
+      - lib/python{{ py_version }}/site-packages/um_ppibm
+      - lib/python{{ py_version }}/site-packages/um_ppibm-{{ version|replace(".0", ".") }}.dist-info
+    requirements:
+      run:
+        - python={{ py_version }}
+        - numpy={{ numpy_version }}
+        - six
+        - shumlib
+        - {{ pin_subpackage('mule-base', exact=True) }}
+    test:
+      imports:
+        - um_ppibm
+
+  - name: mule-um-utils
+    files:
+      - bin
+      - lib/python{{ py_version }}/site-packages/um_utils
+      - lib/python{{ py_version }}/site-packages/um_utils-{{ version|replace(".0", ".") }}.dist-info
+    requirements:
+      run:
+        - python={{ py_version }}
+        - numpy={{ numpy_version }}
+        - six
+        - pillow
+        - shumlib
+        - {{ pin_subpackage('mule-base', exact=True) }}
+        - {{ pin_subpackage('mule-um-ppibm', exact=True) }}
+    test:
+      imports:
+        - um_utils
+      commands:
+        # Rename test to avoid module name clash
+        - mv ${SP_DIR}/um_utils/tests/select ${SP_DIR}/um_utils/tests/mule_select
+        - python -m unittest discover -vs ${SP_DIR}/um_utils/tests
+        - mule-convpp -h
+        - mule-cumf -h
+        - mule-cutout -h
+        - mule-editmask -h
+        - mule-fixframe -h
+        - mule-pumf -h
+        - mule-select -h
+        - mule-summary -h
+        - mule-trim -h
+        - mule-unpack -h
+        - mule-version -h
+
+  # Explicitly define metapackage for installing Mule
+  - name: mule
+    requirements:
+      run:
+        - python={{ py_version }}
+        - numpy={{ numpy_version }}
+        - six
+        - pillow
+        - shumlib
+        - {{ pin_subpackage('mule-um-spiral-search', exact=True) }}
+        - {{ pin_subpackage('mule-um-packing', exact=True) }}
+        - {{ pin_subpackage('mule-base', exact=True) }}
+        - {{ pin_subpackage('mule-um-ppibm', exact=True) }}
+        - {{ pin_subpackage('mule-um-utils', exact=True) }}
+
+about:
+  home: https://github.com/metomi/mule
+  license: BSD
+  license_family: BSD
+  summary: Mule is a Python API for accessing the various file types used by the UM; the UK Met Office's Unified Model.

--- a/conda/mule/um_ppibm_setup.patch
+++ b/conda/mule/um_ppibm_setup.patch
@@ -1,0 +1,8 @@
+--- um_ppibm/setup.py   2024-08-05 01:45:58.434007000 +0000
++++ um_ppibm/setup.py   2024-08-05 01:46:15.405934457 +0000
+@@ -66,4 +66,5 @@
+             include_dirs=[np.get_include()],
+             libraries=["shum_string_conv",
+                        "shum_byteswap",
++                       "shum_string_conv",
+                        "shum_data_conv"])])

--- a/conda/mule/um_utils_select_exit_code.patch
+++ b/conda/mule/um_utils_select_exit_code.patch
@@ -1,0 +1,11 @@
+--- um_utils/lib/um_utils/select.py     2024-07-31 04:22:58.913175163 +0000
++++ um_utils/lib/um_utils/select.py     2024-08-05 02:23:14.380718080 +0000
+@@ -183,6 +183,8 @@
+     # include/exclude flag and a value for it)
+     if len(sys.argv) < 4:
+         parser.print_help()
++        if len(sys.argv) == 2 and sys.argv[1] in ['-h', '--help']:
++            parser.exit(0)
+         parser.exit(1)
+
+     # Print version information

--- a/conda/shumlib/build.sh
+++ b/conda/shumlib/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -ex
+
+export LIBDIR_OUT=${PREFIX}
+export SHUM_OPENMP=true
+
+# Make sure that the conda-provided toolchain is used
+sed -i "s;FPP=cpp;FPP=${CPP};" make/vm-x86-gfortran-gcc.mk
+sed -i "/FC=gfortran/d" make/vm-x86-gfortran-gcc.mk
+sed -i "/CC=gcc/d" make/vm-x86-gfortran-gcc.mk
+sed -i "s;AR=ar;AR=${AR};" make/vm-x86-gfortran-gcc.mk
+
+# Build the libraries
+make -f make/vm-x86-gfortran-gcc.mk
+
+# Run tests
+make -f make/vm-x86-gfortran-gcc.mk check
+
+# Clean up
+make -f make/vm-x86-gfortran-gcc.mk clean-temp
+rm -r ${PREFIX}/tests
+rm ${PREFIX}/include/{fruit.mod,fruit_util.mod}
+rm ${PREFIX}/lib/{libfruit.a,libfruit.so}

--- a/conda/shumlib/meta.yaml
+++ b/conda/shumlib/meta.yaml
@@ -1,0 +1,30 @@
+{% set name = "shumlib" %}
+{% set version = "2024.03.1" %}
+{% set revision = "7373" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  svn_url: <Insert MOSRS svn url>/utils/shumlib/trunk
+  svn_rev: "{{ revision }}"
+
+requirements:
+  build:
+    - sed
+    - make
+    - {{ compiler('c') }}
+    - {{ compiler('fortran') }}
+
+test:
+  commands:
+    # Sanity checks only, unit tests run as part of the build
+    - test -f ${PREFIX}/lib/libshum.so
+    - test -f ${PREFIX}/lib/libshum.a
+
+about:
+  home: https://github.com/metomi/shumlib
+  license: BSD
+  license_family: BSD
+  summary: Shumlib is the collective name for a set of libraries which are used by the UM; the UK Met Office's Unified Model, that may be of use to external tools or applications where identical functionality is desired.

--- a/conda/shumlib/meta.yaml
+++ b/conda/shumlib/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: "{{ version }}"
 
 source:
-  svn_url: <Insert MOSRS svn url>/utils/shumlib/trunk
+  svn_url: {{ environ.get('NGMOENVS_MOSRS_MIRROR', 'https://code.metoffice.gov.uk/svn') }}/utils/shumlib/trunk
   svn_rev: "{{ revision }}"
 
 requirements:


### PR DESCRIPTION
I recently needed to build Conda packages for Shumlib, Mule, and ANTS on the NIWA HPC, so I thought I'd share the recipes in case this is useful for the Momentum Partnership. There are currently two limitations:

- The Mule package does not currently build all possible sub-packages
- All three packages rely on source codes from MOSRS, so they require setting up Subversion URLs in the `meta.yaml` files before they can be built - this problem may be resolved by GitHub migration

It could also be considered to upload package builds to conda-forge, if the package developers are happy with making them publicly available, which would greatly simplify installation.