### PR TITLE
Add CI support for NCI gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,11 @@
+stages:
+    - build
+    - test
+    - deploy
+    - clean
+
+# If this $SITE has defined CI, use that
+include: 
+    local: site/$SITE/ci/gitlab-ci.yml
+    rules:
+        - exists: site/$SITE/ci/gitlab-ci.yml

--- a/site/nci/README.md
+++ b/site/nci/README.md
@@ -42,3 +42,25 @@ executable inside the container you must also run it inside the container.
 envrun make
 envrun mpirun -n 6 lfric
 ```
+
+## Developing environments
+
+Develop environments in our local mirror of this repository at
+https://git.nci.org.au/bom/ngm/ngmo-environments/. CI is set up to
+automatically build branches, the built environments are usable with
+
+```
+module use /scratch/hc46/hc46_gitlab/ngm/modules
+module load ngmo-envs/lfric/$BRANCH
+```
+
+Once a change has been developed locally create a pull request on the Met
+Office repository https://github.com/metoffice/ngmo-environments to make it
+available at all sites.
+
+Builds off of the Met Office repository are usable with
+
+```
+module use /g/data/access/ngm/modules/envs
+module load lfric
+```

--- a/site/nci/ci/gitlab-ci-env.yml
+++ b/site/nci/ci/gitlab-ci-env.yml
@@ -1,0 +1,72 @@
+# This file should be included once for each environment being built
+spec:
+    inputs:
+        environment:
+---
+
+# Variables applied to all tasks
+variables:
+    ENV: $[[ inputs.environment ]]
+    VERSION: $CI_COMMIT_BRANCH
+    NGMOENVS_ENVDIR: /scratch/hc46/hc46_gitlab/ngmo-envs/envs/$ENV/$VERSION
+
+# Build the environment
+build:$[[ inputs.environment ]]:
+    stage: build
+    script:
+        - ./site/nci/install.sh "$ENV"
+    after_script:
+        - cat "ngmoenvs1-$ENV.o"*
+        - cat "ngmoenvs2-$ENV.o"*
+    environment: 
+        name: development/$[[ inputs.environment ]]/$CI_COMMIT_BRANCH
+        action: start
+        # Automatically clean up the install after a week
+        on_stop: clean:$[[ inputs.environment ]]
+        auto_stop_in: 1 week
+    tags:
+        - gadi
+
+# Run environment test script
+test:$[[ inputs.environment ]]:
+    stage: test
+    script:
+        - ./tests/site/nci.sh lfric
+    environment: 
+        name: development/$[[ inputs.environment ]]/$CI_COMMIT_BRANCH
+        action: access
+    needs:
+      - job: build:$[[ inputs.environment ]]
+    tags:
+        - gadi
+
+# Clean the environment
+clean:$[[ inputs.environment ]]:
+    stage: clean
+    script:
+        - rm -rf "$NGMOENVS_ENVDIR"
+    environment:
+        name: development/$[[ inputs.environment ]]/$CI_COMMIT_BRANCH
+        action: stop
+    when: manual
+    tags:
+        - gadi
+
+# Deploy environment to /g/data/access
+deploy:$[[ inputs.environment ]]:
+    stage: deploy
+    script:
+        - ./site/nci/deploy.sh "$ENV"
+    after_script:
+        - cat "ngmoenvs1-$ENV.o"*
+        - cat "ngmoenvs2-$ENV.o"*
+    environment:
+        name: production/$[[ inputs.environment ]]
+        action: start
+    needs:
+      - job: test:$[[ inputs.environment ]]
+    rules:
+      - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+        when: manual
+    tags:
+        - gadi

--- a/site/nci/ci/gitlab-ci.yml
+++ b/site/nci/ci/gitlab-ci.yml
@@ -1,0 +1,8 @@
+include:
+    # Include gitlab-ci-env.yml once for each environment
+    - local: site/nci/ci/gitlab-ci-env.yml
+      inputs:
+          environment: lfric
+  # - local: site/nci/ci/gitlab-ci-env.yml
+  #   inputs:
+  #       environment: jopa

--- a/site/nci/deploy.sh
+++ b/site/nci/deploy.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Install the environment into /g/data/access
+
+set -eu
+set -o pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "$(readlink -f "${BASH_SOURCE[0]}")" )" &> /dev/null && pwd )
+
+export ENVIRONMENT="$1"
+
+# Install version
+export VERSION=$(date +%y%m)
+
+# Path to install the environment to
+export NGMOENVS_ENVDIR=/g/data/access/ngm/envs/$ENVIRONMENT/$VERSION
+
+# Path to install the modulefile to
+export NGMOENVS_MODULE=/g/data/access/ngm/modules/$ENVIRONMENT/$VERSION
+
+if [[ -f "$NGMOENVS_ENVDIR" ]]; then
+    echo "Environment $ENVIRONMENT alread exists at $NGMOENVS_ENVDIR"
+    exit 1
+fi
+
+# Run the install script with the pre-set central install paths
+$SCRIPT_DIR/install.sh $ENVIRONMENT
+

--- a/site/nci/env.sh
+++ b/site/nci/env.sh
@@ -9,13 +9,6 @@ source "$SITE_DIR/../../utils/common.sh"
 : "${NGMOENVS_TMPDIR:=${TMPDIR:-/tmp}}"
 export NGMOENVS_TMPDIR
 
-# Base directory for environments
-: "${NGMOENVS_BASEDIR:="$HOME/ngmo-envs"}"
-
-# Path to install the environment to on the host
-export ENVDIR="${NGMOENVS_BASEDIR}/envs/${ENVIRONMENT}"
-export INSTALL_ENVDIR="$ENVDIR"
-
 # Host filesystem path for building squashfs
 export LOCALSQUASHFS="$NGMOENVS_TMPDIR/squashfs"
 

--- a/site/nci/env.sh
+++ b/site/nci/env.sh
@@ -26,3 +26,7 @@ export MKSQUASHFS=/usr/sbin/mksquashfs
 
 # Prebuild base image
 export NGMOENVS_BASEIMAGE=/g/data/access/ngm/data/gadicontainer/202407/ngmoenvs-baseimage.sif
+
+# Isolate Spack
+export SPACK_DISABLE_LOCAL_CONFIG=true
+export SPACK_USER_CACHE_PATH="$TMPDIR/spack"

--- a/site/nci/install-stage-two.sh
+++ b/site/nci/install-stage-two.sh
@@ -30,7 +30,20 @@ export SINGULARITYENV_LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:/system/lib64"
 # Build the spack packages themselves
 export NGMOENVS_ENVDIR="${CONTAINER_ENVDIR}"
 export ENVIRONMENT
-e "${APPTAINER[@]}" run "${MOUNT_ARGS[@]}" "$NGMOENVS_BASEIMAGE" /bin/bash "${SITE_DIR}/../../utils/install-stage-two.sh"
+
+if [[ -v NGMOENVS_DEBUG ]]; then
+    # Running in debug mode, start a shell in the container
+    e "${APPTAINER[@]}" run "${MOUNT_ARGS[@]}" "$NGMOENVS_BASEIMAGE" /bin/bash
+    exit 0
+fi
+
+if ! e "${APPTAINER[@]}" run "${MOUNT_ARGS[@]}" "$NGMOENVS_BASEIMAGE" /bin/bash "${SITE_DIR}/../../utils/install-stage-two.sh"; then
+    # Copy failed build logs to scratch
+    mkdir -p /scratch/$PROJECT/$USER/tmp/spack-stage
+    cp -r $TMPDIR/$USER/spack-stage/* /scratch/$PROJECT/$USER/tmp/spack-stage
+    echo "Logs available under /scrach/$PROJECT/$USER/tmp/spack-stage"
+    exit 1
+fi
 
 # Convert to squashfs
 SQUASHFS="$INSTALL_ENVDIR/etc/$ENVIRONMENT.squashfs"

--- a/site/nci/install.sh
+++ b/site/nci/install.sh
@@ -92,7 +92,7 @@ else
         -N "ngmoenvs2-$ENVIRONMENT" \
         -q normal \
         -l ncpus=8 \
-        -l walltime=1:00:00 \
+        -l walltime=2:00:00 \
         -l mem=32gb \
         -l jobfs=50gb \
         "${QSUB_FLAGS[@]}" \

--- a/site/nci/install.sh
+++ b/site/nci/install.sh
@@ -11,7 +11,7 @@ export ENVIRONMENT="$1"
 export NGMOENVS_BASEDIR
 
 # Version defaults to current git branch
-: "${VERSION="$(git sybmolic-ref --short HEAD)"}"
+: "${VERSION="$(git symbolic-ref --short HEAD)"}"
 export VERSION
 
 # Path to install the environment to
@@ -53,14 +53,17 @@ if ! [[ -v NGMOENVS_DEBUG ]]; then
         -N "ngmoenvs1-$ENVIRONMENT" \
         -q copyq \
         -l ncpus=1 \
-        -l walltime=0:10:00 \
+        -l walltime=0:30:00 \
         -l mem=4gb \
         "${QSUB_FLAGS[@]}" \
         -W block=true \
         -- bash "$SITE_DIR/install-stage-one.sh" "$ENVIRONMENT")
     EXIT=$?
 
-    [[ $EXIT -eq 0 ]] || exit $EXIT
+    if ! [[ $EXIT -eq 0 ]]; then
+        error "Building stage 1"
+        exit $EXIT
+    fi
 
     # Second stage does the spack builds
     JOBID=$(e qsub \
@@ -75,7 +78,10 @@ if ! [[ -v NGMOENVS_DEBUG ]]; then
         -- bash "$SITE_DIR/install-stage-two.sh" "$ENVIRONMENT")
     EXIT=$?
 
-    [[ $EXIT -eq 0 ]] || exit $EXIT
+    if ! [[ $EXIT -eq 0 ]]; then
+        error "Building stage 2"
+        exit $EXIT
+    fi
 
     set -e
 else

--- a/site/nci/install.sh
+++ b/site/nci/install.sh
@@ -10,6 +10,17 @@ export ENVIRONMENT="$1"
 : "${NGMOENVS_BASEDIR:="/scratch/$PROJECT/$USER/ngmo-envs"}"
 export NGMOENVS_BASEDIR
 
+# Version defaults to current git branch
+: "${VERSION="$(git sybmolic-ref --short HEAD)"}"
+export VERSION
+
+# Path to install the environment to
+: "${NGMOENVS_ENVDIR:="$NGMOENVS_BASEDIR/envs/$ENVIRONMENT/$VERSION"}"
+export NGMOENVS_ENVDIR
+
+# Path for modulefiles
+: "${NGMOENVS_MODULE:="$NGMOENVS_BASEDIR/modules/$ENVIRONMENT/$VERSION"}"
+
 # Cache paths
 : "${NGMOENVS_SPACK_MIRROR:="file://$NGMOENVS_BASEDIR/spack-mirror"}"
 : "${CONDA_BLD_PATH:="$NGMOENVS_BASEDIR/conda-bld"}"
@@ -21,60 +32,77 @@ export CONDA_BLD_PATH
 : "${NGMOENVS_MPI:="openmpi@4.1.5"}"
 export NGMOENVS_COMPILER NGMOENVS_MPI
 
-VERSION="$(git describe --always)"
-export VERSION
-
 # shellcheck source=site/nci/env.sh
 source "$SITE_DIR/env.sh"
 
-# Run the apptainer build in the queue
-# First stage is everything requiring networking - only download spack sources
-STAGE1=$(qsub \
-    -N "ngmoenvs1-$ENVIRONMENT" \
+QSUB_FLAGS=(
     -P "$PROJECT" \
-    -q copyq \
-    -l ncpus=1 \
-    -l walltime=1:00:00 \
-    -l mem=4gb \
     -l jobfs=50gb \
     -l storage=gdata/access+gdata/ki32 \
     -j oe \
     -W umask=0022 \
-    -v PROJECT,NGMOENVS_BASEDIR,NGMOENVS_COMPILER,NGMOENVS_MPI,NGMOENVS_BASEIMAGE,NGMOENVS_MOSRS_MIRROR,NGMOENVS_SPACK_MIRROR,CONDA_BLD_PATH,APPTAINER,MKSQUASHFS,SPACK_DOWNLOAD_ONLY=true \
-    -- bash "$SITE_DIR/install-stage-one.sh" "$ENVIRONMENT"
+    -v PROJECT,NGMOENVS_BASEDIR,NGMOENVS_COMPILER,NGMOENVS_MPI,NGMOENVS_SPACK_MIRROR,CONDA_BLD_PATH,SPACK_DOWNLOAD_ONLY=true,INSTALL_ENVDIR="${NGMOENVS_ENVDIR}" \
 )
-echo "$STAGE1"
 
-# Second stage does the spack builds
-qsub \
-    -N "ngmoenvs2-$ENVIRONMENT" \
-    -P "$PROJECT" \
-    -q normal \
-    -l ncpus=8 \
-    -l walltime=1:00:00 \
-    -l mem=32gb \
-    -l jobfs=50gb \
-    -l storage=gdata/access+gdata/ki32 \
-    -l wd \
-    -j oe \
-    -m ae \
-    -W umask=0022 \
-    -v PROJECT,NGMOENVS_BASEDIR,NGMOENVS_COMPILER,NGMOENVS_MPI,NGMOENVS_BASEIMAGE,NGMOENVS_MOSRS_MIRROR,NGMOENVS_SPACK_MIRROR,CONDA_BLD_PATH,APPTAINER,MKSQUASHFS,SPACK_DOWNLOAD_ONLY=true \
-    -W "depend=afterok:$STAGE1" \
-    -- bash "$SITE_DIR/install-stage-two.sh" "$ENVIRONMENT"
+if ! [[ -v NGMOENVS_DEBUG ]]; then
+    set +e
 
-MODULE="$NGMOENVS_BASEDIR/modules/$ENVIRONMENT"
+    # Run the apptainer build in the queue
+    # First stage is everything requiring networking - only download spack sources
+    JOBID=$(e qsub \
+        -N "ngmoenvs1-$ENVIRONMENT" \
+        -q copyq \
+        -l ncpus=1 \
+        -l walltime=0:10:00 \
+        -l mem=4gb \
+        "${QSUB_FLAGS[@]}" \
+        -W block=true \
+        -- bash "$SITE_DIR/install-stage-one.sh" "$ENVIRONMENT")
+    EXIT=$?
 
-mkdir -p "$(dirname "$MODULE")"
-cat > "$MODULE" << EOF
+    [[ $EXIT -eq 0 ]] || exit $EXIT
+
+    # Second stage does the spack builds
+    JOBID=$(e qsub \
+        -N "ngmoenvs2-$ENVIRONMENT" \
+        -q normal \
+        -l ncpus=8 \
+        -l walltime=1:00:00 \
+        -l mem=32gb \
+        -l jobfs=50gb \
+        "${QSUB_FLAGS[@]}" \
+        -W block=true \
+        -- bash "$SITE_DIR/install-stage-two.sh" "$ENVIRONMENT")
+    EXIT=$?
+
+    [[ $EXIT -eq 0 ]] || exit $EXIT
+
+    set -e
+else
+
+    echo Run: "$SITE_DIR/install-stage-two.sh" "$ENVIRONMENT"
+
+    qsub \
+        -N "ngmoenvs2-$ENVIRONMENT" \
+        -q normal \
+        -l ncpus=8 \
+        -l walltime=1:00:00 \
+        -l mem=32gb \
+        -l jobfs=50gb \
+        "${QSUB_FLAGS[@]}" \
+        -I
+fi
+
+mkdir -p "$(dirname "$NGMOENVS_MODULE")"
+cat > "$NGMOENVS_MODULE" << EOF
 #%Module1.0
 
 set name         "$ENVIRONMENT"
-set version      "$(git describe --always)"
-set origin       "$(git remote get-url origin)"
+set version      "$VERSION"
+set origin       "$(git remote get-url origin) $(git rev-parse HEAD)"
 set install_date "$(date --iso=minute)"
 set installed_by "$USER - $(getent passwd "$USER" | cut -d ':' -f 5)"
-set prefix       "$INSTALL_ENVDIR"
+set prefix       "$NGMOENVS_ENVDIR"
 
 proc ModulesHelp {} {
     global name version origin install_date installed_by
@@ -82,7 +110,7 @@ proc ModulesHelp {} {
     puts stderr "NGMO Environment \$name/\$version"
     puts stderr "  Install info:"
     puts stderr "    repo: \$origin"
-    puts stderr "    rev:  \$version"
+    puts stderr "    ver:  \$version"
     puts stderr "    date: \$install_date"
     puts stderr "    by:   \$installed_by"
 }
@@ -95,14 +123,17 @@ setenv \${name_upcase}_VERSION "\$version"
 prepend-path PATH "\$prefix/bin"
 EOF
 
-mkdir -p "$INSTALL_ENVDIR/bin"
-cp "$SITE_DIR/envrun" "$INSTALL_ENVDIR/bin"
-chmod +x "$INSTALL_ENVDIR/bin/envrun"
+mkdir -p "$NGMOENVS_ENVDIR/bin"
+cp "$SITE_DIR/envrun" "$NGMOENVS_ENVDIR/bin"
+chmod +x "$NGMOENVS_ENVDIR/bin/envrun"
 
 cat <<EOF
 
-Once PBS jobs are complete load the environment with
+Environment build complete
 
-    module use "$NGMOENVS_BASEDIR/modules"
-    module load "$ENVIRONMENT"
+Load the environment with
+
+    module load "$NGMOENVS_MODULE"
+
+Prepend commands with 'envrun' to run them in the container
 EOF

--- a/site/nci/spack-packages.yaml
+++ b/site/nci/spack-packages.yaml
@@ -22,4 +22,24 @@ packages:
             append_path:
               # Fix up runtime environment
               LD_LIBRARY_PATH: /apps/intel-oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin:/system/lib64
+      - spec: "openmpi@4.1.5%oneapi"
+        prefix: "/apps/openmpi/4.1.5"
+        extra_attributes:
+          environment:
+            set:
+              # Use the spack compilers when building packages
+              OMPI_CC: /ngmo/spack/lib/spack/env/oneapi/icx
+              OMPI_CXX: /ngmo/spack/lib/spack/env/oneapi/icpx
+              OMPI_FC: /ngmo/spack/lib/spack/env/oneapi/ifx
+              # Fix up the combined intel/gcc install
+              OMPI_FCFLAGS: -I/apps/openmpi/4.1.5/include/Intel
+              OMPI_LDFLAGS: -L/apps/openmpi/4.1.5/lib -L/apps/openmpi/4.1.5/lib/Intel -L/system/lib64 -Wl,-rpath=/apps/openmpi/4.1.5/lib -L/apps/intel-oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin -Wl,-rpath=/apps/intel-oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin
+            append_path:
+              # Fix up runtime environment
+              LD_LIBRARY_PATH: /apps/intel-oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin:/system/lib64
     buildable: False
+  yaxt:
+    require: '%intel'
+  blitz:
+      # Needs setup for oneapi
+    require: '%intel'

--- a/tests/envs/lfric.sh
+++ b/tests/envs/lfric.sh
@@ -42,6 +42,8 @@ envrun lfric_apps/build/local_build.py --application "$APP" --core_source "$BASE
 pushd "$BASEDIR/lfric_apps/applications/$APP/example"
 envrun mpirun -n 6 "../bin/$APP" configuration.nml
 
+cat PET0.*.Log
+
 cat <<EOF
 
 LFRic app $APP successfully ran!

--- a/tests/site/nci.sh
+++ b/tests/site/nci.sh
@@ -15,6 +15,7 @@ ENVIRONMENT="$1"
 module purge
 module use "/scratch/$PROJECT/$USER/ngmo-envs/modules"
 module load "$ENVIRONMENT"
+module list
 
 # Set up run directory
 export BASEDIR="$TMPDIR/ngmo-envs-test/lfric"

--- a/utils/bootstrap.sh
+++ b/utils/bootstrap.sh
@@ -14,7 +14,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "$(readlink -f "${BASH_SOURCE[0]}")" )" &> /d
 # shellcheck source=utils/common.sh
 source "$SCRIPT_DIR/common.sh"
 
-SPACK_VERSION=0.22.0
+SPACK_VERSION=0.22.2
 export SPACK_DISABLE_LOCAL_CONFIG=1
 
 mkdir -p "$NGMOENVS_BASEDIR/bin"

--- a/utils/install-stage-two.sh
+++ b/utils/install-stage-two.sh
@@ -17,11 +17,22 @@ source "$SCRIPT_DIR/common.sh"
 # Activate the environment
 e spack env activate "$NGMOENVS_ENVDIR/spack"
 
+# Disable external bootstrap repos
+e spack bootstrap disable github-actions-v0.5
+e spack bootstrap disable github-actions-v0.4
+
+e spack config blame
+
 # Solve dependencies again in case node type changed
 e spack concretize --fresh --force
 
 # Install everything
-e spack install
+if ! e spack install; then
+
+    # Push completed packages to cache
+    e spack buildcache push ngmo-spack-local $(spack find --format '/{hash}')
+    exit 1
+fi
 
 # Run the post-install with the environment in place
 export ENVDEFS="${NGMOENVS_DEFS}/environments/${ENVIRONMENT}"


### PR DESCRIPTION
Build environments using NCI's Gitlab CI.

The environments will be automatically built in the hc46 project, and may be manually deployed to /g/data/access through the gitlab pipeline.

Changes in the public Github repository must be manually synced to NCI's Gitlab to be able to built, there is not automatic mirroring.

Other sites can use Gitlab CI by adding their own gitlab-ci.yaml file to `site/$SITE/ci/gitlab-ci.yaml`