### PR TITLE
Try to fix xios build on xios13.

### DIFF
--- a/spack/packages/xios/gcc_remap.patch
+++ b/spack/packages/xios/gcc_remap.patch
@@ -1,26 +1,26 @@
 Index: extern/remap/src/earcut.hpp
 ===================================================================
---- extern/remap/src/earcut.hpp	(revision 2252)
-+++ extern/remap/src/earcut.hpp	(working copy)
+--- a/extern/remap/src/earcut.hpp       (revision 2252)
++++ b/extern/remap/src/earcut.hpp       (working copy)
 @@ -6,6 +6,9 @@
- #include <memory>
- #include <vector>
- #include <limits>
-+// Using stdint.h instead of cstdint ensures that the symbols
-+// are in the global namespace ... which is how uint32_t is used
-+#include <stdint.h>
- //#include <tuple>
- //#include <cstdint> 
- //#include <cstddef>
+#include <memory>
+#include <vector>
+#include <limits>
++// Using cstdint ensures that the symbols are in the
++// global namespace and in std ... which is how uint32_t is used
++#include <cstdint>
+//#include <tuple>
+//#include <cstdint> 
+//#include <cstddef>
 Index: extern/remap/src/meshutil.cpp
 ===================================================================
---- extern/remap/src/meshutil.cpp	(revision 2252)
-+++ extern/remap/src/meshutil.cpp	(working copy)
+--- a/extern/remap/src/meshutil.cpp     (revision 2252)
++++ b/extern/remap/src/meshutil.cpp     (working copy)
 @@ -4,6 +4,7 @@
- #include "intersection_ym.hpp"
- #include "earcut.hpp"
- #include <vector>
+#include "intersection_ym.hpp"
+#include "earcut.hpp"
+#include <vector>
 +#include <array>
- 
- namespace sphereRemap {
- 
+
+namespace sphereRemap {
+

--- a/spack/packages/xios/gcc_remap.patch
+++ b/spack/packages/xios/gcc_remap.patch
@@ -1,9 +1,26 @@
---- a/extern/remap/src/meshutil.cpp	(revision 2397)
-+++ b/extern/remap/src/meshutil.cpp	(revision 2398)
-@@ -5,4 +5,5 @@
+Index: extern/remap/src/earcut.hpp
+===================================================================
+--- extern/remap/src/earcut.hpp	(revision 2252)
++++ extern/remap/src/earcut.hpp	(working copy)
+@@ -6,6 +6,9 @@
+ #include <memory>
+ #include <vector>
+ #include <limits>
++// Using stdint.h instead of cstdint ensures that the symbols
++// are in the global namespace ... which is how uint32_t is used
++#include <stdint.h>
+ //#include <tuple>
+ //#include <cstdint> 
+ //#include <cstddef>
+Index: extern/remap/src/meshutil.cpp
+===================================================================
+--- extern/remap/src/meshutil.cpp	(revision 2252)
++++ extern/remap/src/meshutil.cpp	(working copy)
+@@ -4,6 +4,7 @@
+ #include "intersection_ym.hpp"
  #include "earcut.hpp"
  #include <vector>
 +#include <array>
  
  namespace sphereRemap {
-
+ 


### PR DESCRIPTION
gcc 13 complains about `uint32_t` not defined in the remap external code of xios. I tried two version:
- `<stdint.h>` failed, since it only declared `uint32_t`, but NOT `std::u_int32` ... and xios (or remap??) uses both versions. 
- Using `<cstdint>` on the other hand worked, though according to the standard it only guarantees `std::uint32_t`, but it apparently also declares `uint32_t`).

I decided to include this with the existing gcc_remap patch, since the changes are similar (missing include), and can't really hurt.

But I had some problems with spack complaining about checksum errors, caused by using a modified patch, which might be a spack bug:
https://github.com/spack/spack/issues/45472

Using `spack clean -m` solved that for me, but I am not sure what the proper solution is. Should I perhaps make this a stand-alone patch?