### PR TITLE
Add support for oneapi

### DIFF
--- a/environments/lfric/conda.yaml
+++ b/environments/lfric/conda.yaml
@@ -8,3 +8,4 @@ dependencies:
   - jinja2
   - sci-fab
   - python-clang
+  - libsqlite <3.49 # Allow double quotes for dependency generator

--- a/site/nci/envrun
+++ b/site/nci/envrun
@@ -18,5 +18,6 @@ export FFLAGS="-I /apps/openmpi/4.1.5/include/Intel ${FFLAGS:-}"
 
 # Pass through LD_LIBRARY_PATH
 export SINGULARITYENV_LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+export SINGULARITYENV_APPEND_PATH="/apps/intel-oneapi/compiler/2023.2.0/linux/bin-llvm"
 
 /opt/singularity/bin/singularity run "${MOUNT_ARGS[@]}" "$ENV_DIR/etc/apptainer.sif" "$@"

--- a/site/nci/envrun
+++ b/site/nci/envrun
@@ -18,6 +18,8 @@ export FFLAGS="-I /apps/openmpi/4.1.5/include/Intel ${FFLAGS:-}"
 
 # Pass through LD_LIBRARY_PATH
 export SINGULARITYENV_LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+
+# Required for oneapi sanitizers to show addresses
 export SINGULARITYENV_APPEND_PATH="/apps/intel-oneapi/compiler/2023.2.0/linux/bin-llvm"
 
 /opt/singularity/bin/singularity run "${MOUNT_ARGS[@]}" "$ENV_DIR/etc/apptainer.sif" "$@"

--- a/site/nci/envrun
+++ b/site/nci/envrun
@@ -20,6 +20,6 @@ export FFLAGS="-I /apps/openmpi/4.1.5/include/Intel ${FFLAGS:-}"
 export SINGULARITYENV_LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
 
 # Required for oneapi sanitizers to show addresses
-export SINGULARITYENV_APPEND_PATH="/apps/intel-oneapi/compiler/2023.2.0/linux/bin-llvm"
+export SINGULARITYENV_APPEND_PATH="/apps/intel-tools/intel-compiler-llvm/2025.0.4/bin/compiler"
 
 /opt/singularity/bin/singularity run "${MOUNT_ARGS[@]}" "$ENV_DIR/etc/apptainer.sif" "$@"

--- a/site/nci/install.sh
+++ b/site/nci/install.sh
@@ -55,7 +55,7 @@ if ! [[ -v NGMOENVS_DEBUG ]]; then
         -N "ngmoenvs1-$ENVIRONMENT" \
         -q copyq \
         -l ncpus=1 \
-        -l walltime=0:30:00 \
+        -l walltime=1:00:00 \
         -l mem=4gb \
         "${QSUB_FLAGS[@]}" \
         -W block=true \

--- a/site/nci/install.sh
+++ b/site/nci/install.sh
@@ -47,7 +47,7 @@ if ! [[ -v NGMOENVS_DEBUG ]]; then
         -N "ngmoenvs2-$ENVIRONMENT" \
         -q normal \
         -l ncpus=8 \
-        -l walltime=1:00:00 \
+        -l walltime=2:00:00 \
         -l mem=32gb \
         -l jobfs=50gb \
         "${QSUB_FLAGS[@]}" \

--- a/site/nci/install.sh
+++ b/site/nci/install.sh
@@ -55,7 +55,7 @@ if ! [[ -v NGMOENVS_DEBUG ]]; then
         -N "ngmoenvs1-$ENVIRONMENT" \
         -q copyq \
         -l ncpus=1 \
-        -l walltime=1:00:00 \
+        -l walltime=0:30:00 \
         -l mem=4gb \
         "${QSUB_FLAGS[@]}" \
         -W block=true \

--- a/site/nci/install.sh
+++ b/site/nci/install.sh
@@ -30,7 +30,7 @@ if ! [[ -v NGMOENVS_DEBUG ]]; then
         -N "ngmoenvs1-$ENVIRONMENT" \
         -q copyq \
         -l ncpus=1 \
-        -l walltime=0:30:00 \
+        -l walltime=1:30:00 \
         -l mem=4gb \
         "${QSUB_FLAGS[@]}" \
         -W block=true \

--- a/site/nci/spack-compilers.yaml
+++ b/site/nci/spack-compilers.yaml
@@ -1,11 +1,11 @@
 compilers:
   - compiler:
-      spec: oneapi@2024.0.2
+      spec: oneapi@2024.2.1
       paths:
-        cc: /apps/intel-tools/intel-compiler-llvm/2024.0.2/bin/icx
-        cxx: /apps/intel-tools/intel-compiler-llvm/2024.0.2/bin/icpx
-        f77: /apps/intel-tools/intel-compiler-llvm/2024.0.2/bin/ifx
-        fc: /apps/intel-tools/intel-compiler-llvm/2024.0.2/bin/ifx
+        cc: /apps/intel-tools/intel-compiler-llvm/2024.2.1/bin/icx
+        cxx: /apps/intel-tools/intel-compiler-llvm/2024.2.1/bin/icpx
+        f77: /apps/intel-tools/intel-compiler-llvm/2024.2.1/bin/ifx
+        fc: /apps/intel-tools/intel-compiler-llvm/2024.2.1/bin/ifx
       flags: {}
       operating_system: rocky8
       target: x86_64

--- a/site/nci/spack-compilers.yaml
+++ b/site/nci/spack-compilers.yaml
@@ -1,11 +1,11 @@
 compilers:
   - compiler:
-      spec: oneapi@2024.2.1
+      spec: oneapi@2025.0.4
       paths:
-        cc: /apps/intel-tools/intel-compiler-llvm/2024.2.1/bin/icx
-        cxx: /apps/intel-tools/intel-compiler-llvm/2024.2.1/bin/icpx
-        f77: /apps/intel-tools/intel-compiler-llvm/2024.2.1/bin/ifx
-        fc: /apps/intel-tools/intel-compiler-llvm/2024.2.1/bin/ifx
+        cc:  /apps/intel-tools/intel-compiler-llvm/2025.0.4/bin/icx
+        cxx: /apps/intel-tools/intel-compiler-llvm/2025.0.4/bin/icpx
+        f77: /apps/intel-tools/intel-compiler-llvm/2025.0.4/bin/ifx
+        fc:  /apps/intel-tools/intel-compiler-llvm/2025.0.4/bin/ifx
       flags: {}
       operating_system: rocky8
       target: x86_64

--- a/site/nci/spack-packages.yaml
+++ b/site/nci/spack-packages.yaml
@@ -53,8 +53,3 @@ packages:
               # Fix up runtime environment
               LD_LIBRARY_PATH: /apps/intel-oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin:/system/lib64
     buildable: False
-  yaxt:
-    require: '%intel'
-  blitz:
-      # Needs setup for oneapi
-    require: '%intel'

--- a/spack/packages/blitz/fujitsu_compiler_specfic_header.patch
+++ b/spack/packages/blitz/fujitsu_compiler_specfic_header.patch
@@ -1,0 +1,37 @@
+diff -Nur spack-src.org/blitz/bzconfig.h spack-src/blitz/bzconfig.h
+--- spack-src.org/blitz/bzconfig.h	2019-10-02 07:50:17.000000000 +0900
++++ spack-src/blitz/bzconfig.h	2023-05-25 15:13:47.000000000 +0900
+@@ -77,6 +77,10 @@
+ /* Pathscale pathCC compiler */
+ #include <blitz/pathscale/bzconfig.h>
+ 
++#elif defined(__FUJITSU)
++/* Fujitsu FCC compiler */
++#include <blitz/fujitsu/bzconfig.h>
++
+ #elif defined(__clang__)
+ /* clang compiler */
+ #include <blitz/llvm/bzconfig.h>
+@@ -93,10 +97,6 @@
+ /* KAI KCC compiler */
+ #include <blitz/kai/bzconfig.h>
+ 
+-#elif defined(__FUJITSU)
+-/* Fujitsu FCC compiler */
+-#include <blitz/fujitsu/bzconfig.h>
+-
+ /* Add other compilers here */
+ 
+ #else
+diff -Nur spack-src.org/m4/ac_compiler_specific_header.m4 spack-src/m4/ac_compiler_specific_header.m4
+--- spack-src.org/m4/ac_compiler_specific_header.m4	2019-10-02 07:50:17.000000000 +0900
++++ spack-src/m4/ac_compiler_specific_header.m4	2023-05-25 15:13:06.000000000 +0900
+@@ -21,7 +21,7 @@
+                                       [COMPILER_VENDOR="gnu"])],
+   [*KCC*],        [COMPILER_VENDOR="kai"],
+   [*pgCC*],       [COMPILER_VENDOR="pgi"],
+-dnl  [*FCC*],        [COMPILER_VENDOR="fujitsu"],
++  [*FCC*],        [COMPILER_VENDOR="fujitsu"],
+   [*pathCC*],     [COMPILER_VENDOR="pathscale"],
+   [*CC*],         [AS_CASE([$target],
+                       [*sgi*],      [COMPILER_VENDOR="sgi"],

--- a/spack/packages/blitz/llvm_compiler_specific_header.patch
+++ b/spack/packages/blitz/llvm_compiler_specific_header.patch
@@ -1,0 +1,12 @@
+diff -Nur spack-src.org/m4/ac_compiler_specific_header.m4 spack-src/m4/ac_compiler_specific_header.m4
+--- spack-src.org/m4/ac_compiler_specific_header.m4	2019-10-02 07:50:17.000000000 +0900
++++ spack-src/m4/ac_compiler_specific_header.m4	2023-05-25 15:13:06.000000000 +0900
+@@ -21,7 +21,8 @@
+                                       [COMPILER_VENDOR="gnu"])],
+   [*KCC*],        [COMPILER_VENDOR="kai"],
+   [*pgCC*],       [COMPILER_VENDOR="pgi"],
+ dnl  [*FCC*],        [COMPILER_VENDOR="fujitsu"],
++  [*icpx*|*icx*],        [COMPILER_VENDOR="llvm"],
+   [*pathCC*],     [COMPILER_VENDOR="pathscale"],
+   [*CC*],         [AS_CASE([$target],
+                       [*sgi*],      [COMPILER_VENDOR="sgi"],

--- a/spack/packages/blitz/package.py
+++ b/spack/packages/blitz/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Blitz(AutotoolsPackage):
+    """N-dimensional arrays for C++"""
+
+    homepage = "https://github.com/blitzpp/blitz"
+    url = "https://github.com/blitzpp/blitz/archive/1.0.2.tar.gz"
+
+    license("LGPL-3.0-only")
+
+    version("1.0.2", sha256="500db9c3b2617e1f03d0e548977aec10d36811ba1c43bb5ef250c0e3853ae1c2")
+
+    depends_on("python@3:", type="build")
+    depends_on("m4", type="build")
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
+    # Fix makefile and include to build with Fujitsu compiler
+    patch("fujitsu_compiler_specfic_header.patch", when="%fj")
+
+    build_targets = ["lib"]
+
+    def check(self):
+        make("check-testsuite")
+        make("check-examples")

--- a/spack/packages/blitz/package.py
+++ b/spack/packages/blitz/package.py
@@ -27,6 +27,7 @@ class Blitz(AutotoolsPackage):
 
     # Fix makefile and include to build with llvm compiler
     patch("llvm_compiler_specific_header.patch", when="%oneapi")
+    force_autoreconf = True
 
     build_targets = ["lib"]
 

--- a/spack/packages/blitz/package.py
+++ b/spack/packages/blitz/package.py
@@ -25,6 +25,9 @@ class Blitz(AutotoolsPackage):
     # Fix makefile and include to build with Fujitsu compiler
     patch("fujitsu_compiler_specfic_header.patch", when="%fj")
 
+    # Fix makefile and include to build with llvm compiler
+    patch("llvm_compiler_specific_header.patch", when="%oneapi")
+
     build_targets = ["lib"]
 
     def check(self):

--- a/spack/packages/tau/package.py
+++ b/spack/packages/tau/package.py
@@ -183,7 +183,7 @@ class Tau(Package):
         if "+mpi" in spec:
             if spec["mpi"].name == "nci-openmpi" or os.path.exists("/opt/nci"):
             # Accomodate multiple paths for mpi directories on nci
-                if self.spec.satisfies('%intel'):
+                if self.spec.satisfies('%intel') or self.spec.satisfies('%oneapi'):
                     useropt.append("-I%s" % join_path(spec["mpi"].prefix.include, "Intel"))
                     useropt.append("-L%s" % join_path(spec["mpi"].prefix.lib, "Intel"))
                     useropt.append("-Wl,-rpath,%s" % join_path(spec["mpi"].prefix.lib, "Intel"))

--- a/spack/packages/xios/package.py
+++ b/spack/packages/xios/package.py
@@ -236,7 +236,7 @@ OASIS_LIB=""
             "--use_extern_boost",
             "--use_extern_blitz",
             "--job",
-            str(1),
+            str(1), # Errors in oneapi parallel builds when > 1
         ]
 
         self.xios_env()

--- a/spack/packages/xios/package.py
+++ b/spack/packages/xios/package.py
@@ -236,7 +236,7 @@ OASIS_LIB=""
             "--use_extern_boost",
             "--use_extern_blitz",
             "--job",
-            str(2),
+            str(1),
         ]
 
         self.xios_env()

--- a/tests/envs/lfric-oneapi.patch
+++ b/tests/envs/lfric-oneapi.patch
@@ -1,0 +1,123 @@
+Index: infrastructure/build/cxx/icpx.mk
+===================================================================
+--- infrastructure/build/cxx/icpx.mk	(nonexistent)
++++ infrastructure/build/cxx/icpx.mk	(working copy)
+@@ -0,0 +1,9 @@
++##############################################################################
++# (c) Crown copyright 2017 Met Office. All rights reserved.
++# The file LICENCE, distributed with this code, contains details of the terms
++# under which the code may be used.
++##############################################################################
++
++$(info ** Chosen Intel C++ compiler)
++
++CXX_RUNTIME_LIBRARY=stdc++
+Index: infrastructure/build/fortran/ifx.mk
+===================================================================
+--- infrastructure/build/fortran/ifx.mk	(nonexistent)
++++ infrastructure/build/fortran/ifx.mk	(working copy)
+@@ -0,0 +1,104 @@
++##############################################################################
++# Copyright (c) 2017,  Met Office, on behalf of HMSO and Queen's Printer
++# For further details please refer to the file LICENCE.original which you
++# should have received as part of this distribution.
++##############################################################################
++# Various things specific to the Intel Fortran compiler.
++##############################################################################
++#
++# This macro is evaluated now (:= syntax) so it may be used as many times as
++# desired without wasting time rerunning it.
++#
++IFORT_VERSION := $(shell ifort -v 2>&1 \
++                       | cut -d' ' -f3 \
++                       | awk -F "." '/[0-9]\.[0-9]/ { yy = $$1 % 100; printf "%03i%02i%02i\n", yy,$$2,$$3}' )
++
++$(info ** Chosen Intel Fortran compiler version $(IFORT_VERSION))
++
++ifeq ($(shell test $(IFORT_VERSION) -lt 0150001; echo $$?), 0)
++  $(error IFort is too old to build dynamo. Must be at least 15.0.1)
++endif
++
++F_MOD_DESTINATION_ARG = -module$(SPACE)
++F_MOD_SOURCE_ARG      = -I
++FORTRAN_RUNTIME       =
++
++FFLAGS_OPENMP  = -qopenmp
++LDFLAGS_OPENMP = -qopenmp
++
++FFLAGS_NO_OPTIMISATION    = -O0
++FFLAGS_SAFE_OPTIMISATION  = -O2 -fp-model strict
++FFLAGS_SAFE_OPTIMISATION  = -O1 -fno-omit-frame-pointer # -fno-optimize-sibling-calls
++FFLAGS_RISKY_OPTIMISATION = -O3 -xhost
++FFLAGS_DEBUG              = -g -traceback
++#
++# By default turning interface warnings on causes "genmod" files to be
++# created. This adds unecessary files to the build so we disable that
++# behaviour.
++#
++FFLAGS_WARNINGS           = -warn all -gen-interfaces nosource
++FFLAGS_UNIT_WARNINGS      = -warn all -gen-interfaces nosource
++FFLAGS_INIT               = -ftrapuv
++
++ifeq ($(shell test $(IFORT_VERSION) -ge 0190000 -a $(IFORT_VERSION) -lt 0190100; echo $$?), 0)
++# It looks like there's a bad interaction between array shape checking and
++# the "matmul" intrinsic in at least some iterations of v19.
++#
++FFLAGS_RUNTIME            = -check all,noshape -fpe0
++else
++FFLAGS_RUNTIME            = -check all,nouninit -fpe0 
++endif
++
++# Certain compile options cause XIOS failures on the Cray xc40 in
++# those fast-debug jobs that write diagnostic. Therefore, we remove
++# them for that platform. Note: the full-debug test can still use
++# these options as it avoids such XIOS use.
++ifdef CRAY_ENVIRONMENT
++# On the Cray xc40 plaforms these options are switched off for fast-debug
++FFLAGS_FASTD_INIT         =
++FFLAGS_FASTD_RUNTIME      =
++else
++# Otherwise, use the same as the default full-debug settings
++FFLAGS_FASTD_INIT         = $(FFLAGS_INIT)
++FFLAGS_FASTD_RUNTIME      = $(FFLAGS_RUNTIME)
++endif
++
++# Option for checking code meets Fortran standard - currently 2008
++FFLAGS_FORTRAN_STANDARD   = -stand f08
++
++#########################################################################
++# Application and file-specific options referenced in
++# build/compile_options.mk files
++#
++# These variables need explanatory comments and need to be exported
++#
++# -qoverride-limits applied to PSy-layer code due to Intel compiler bug
++# ref #1486
++# When the Intel bug is fixed, this option will be removed by #1490
++export FFLAGS_INTEL_FIX_ARG         = -qoverride-limits
++#
++# -warn noexternals applied to code that imports mpi_mod to avoid
++# a warning-turned-error about missing interfaces for MPI calls in
++# mpi.mod, such as MPI_Allreduce - switching to mpi_f08.mod resolves
++# this via polymorphic interface declarations. Some SOCRATES functions
++# do not currently declare interfaces either. Flag was introduced in
++# Intel Fortran v19.1.0 according to Intel release notes.
++ifeq ($(shell test "$(IFORT_VERSION)" -ge 0190100; echo $$?), 0)
++  $(info ** Activating externals warning override for selected source files)
++  export FFLAGS_INTEL_EXTERNALS = -warn noexternals
++else
++  export FFLAGS_INTEL_EXTERNALS =
++endif
++########################################################################
++
++# The "-assume realloc-lhs" switch causes Intel Fortran prior to v17 to
++# actually implement the Fortran2003 standard. At version 17 it becomes the
++# default behaviour.
++ifeq ($(shell test "$(IFORT_VERSION)" -lt 0170000; echo $$?), 0)
++  $(info ** Activating Intel "Make it work" switch for version earlier than 17)
++  FFLAGS_COMPILER += -assume realloc-lhs
++endif
++
++LDFLAGS_COMPILER = -check all,nouninit
++
++FPPFLAGS = -P

--- a/tests/envs/lfric.sh
+++ b/tests/envs/lfric.sh
@@ -3,6 +3,8 @@
 set -eu
 set -o pipefail
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "$(readlink -f "${BASH_SOURCE[0]}")" )" &> /dev/null && pwd )
+
 cat <<EOF
 Running lfric_apps test in $BASEDIR
 
@@ -26,6 +28,9 @@ if [[ ! -d "$BASEDIR/lfric_core" ]]; then
  FFLAGS_UNIT_WARNINGS      = -warn all -gen-interfaces nosource
  FFLAGS_INIT               = -ftrapuv
 EOF
+
+    # Fix for oneapi
+    patch -p0 --forward --directory "$BASEDIR/lfric_core" < "$SCRIPT_DIR/lfric-oneapi.patch"
 fi
 
 APP=gravity_wave

--- a/tests/site/nci.sh
+++ b/tests/site/nci.sh
@@ -16,7 +16,7 @@ ENVIRONMENT="$1"
 # Load the environment
 module purge
 module use "/scratch/$PROJECT/$USER/ngmo-envs/modules"
-module load "$ENVIRONMENT/$VERSION"
+module load "$ENVIRONMENT"
 module list
 
 # Set up run directory

--- a/tests/site/nci.sh
+++ b/tests/site/nci.sh
@@ -9,12 +9,14 @@ set -o pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "$(readlink -f "${BASH_SOURCE[0]}")" )" &> /dev/null && pwd )
 
+source $SCRIPT_DIR/../../utils/common.sh
+
 ENVIRONMENT="$1"
 
 # Load the environment
 module purge
 module use "/scratch/$PROJECT/$USER/ngmo-envs/modules"
-module load "$ENVIRONMENT"
+module load "$ENVIRONMENT/$VERSION"
 module list
 
 # Set up run directory

--- a/tests/site/nci.sh
+++ b/tests/site/nci.sh
@@ -9,8 +9,6 @@ set -o pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "$(readlink -f "${BASH_SOURCE[0]}")" )" &> /dev/null && pwd )
 
-source $SCRIPT_DIR/../../utils/common.sh
-
 ENVIRONMENT="$1"
 
 # Load the environment

--- a/utils/bootstrap.sh
+++ b/utils/bootstrap.sh
@@ -25,7 +25,7 @@ if [[ ! -f "bin/micromamba" ]]; then
 fi
 
 export MAMBA_ROOT_PREFIX="$NGMOENVS_BASEDIR/conda"
-e "$NGMOENVS_BASEDIR/bin/micromamba" install -y -c conda-forge -n base conda conda-build
+e "$NGMOENVS_BASEDIR/bin/micromamba" install -y -c conda-forge -n base conda conda-build python=3.12
 
 # shellcheck disable=SC1091
 source "$NGMOENVS_BASEDIR/conda/etc/profile.d/conda.sh"

--- a/utils/spack-packages.yaml
+++ b/utils/spack-packages.yaml
@@ -22,3 +22,7 @@ packages:
     conflict:
       - spec: "@2.42"
         message: "Identifier LONG_MIN is undefined"
+  papi:
+      conflict:
+          - spec: "%oneapi"
+            message: "Error in patch"

--- a/utils/spack-packages.yaml
+++ b/utils/spack-packages.yaml
@@ -31,6 +31,9 @@ packages:
           # Not yet set up to run with oneapi
           - "%oneapi"
       require:
+          # If building everything with oneapi compile xios with intel
+          # to get compatible fortran modules
+          #
           # Get the compiler type by matching against dependency netcdf-c
           # If the default compiler is oneapi use intel for xios
           # Blitz compiler must match xios

--- a/utils/spack-packages.yaml
+++ b/utils/spack-packages.yaml
@@ -26,3 +26,24 @@ packages:
       conflict:
           - spec: "%oneapi"
             message: "Error in patch"
+  xios:
+      conflict:
+          # Not yet set up to run with oneapi
+          - "%oneapi"
+      require:
+          # Get the compiler type by matching against dependency netcdf-c
+          # If the default compiler is oneapi use intel for xios
+          # Blitz compiler must match xios
+          - one_of:
+              - "%intel ^netcdf-c%oneapi ^blitz%intel"
+              - "%intel ^netcdf-c%intel  ^blitz%intel"
+              - "%gcc   ^netcdf-c%gcc    ^blitz%gcc"
+              - "%nvhpc ^netcdf-c%nvhpc  ^blitz%nvhpc"
+  blitz:
+      # Remove the compiler constraint so it can satisfy XIOS
+      require:
+          - one_of:
+              - "%intel"
+              - "%oneapi"
+              - "%gcc"
+              - "%nvhpc"

--- a/utils/spack-packages.yaml
+++ b/utils/spack-packages.yaml
@@ -26,27 +26,3 @@ packages:
       conflict:
           - spec: "%oneapi"
             message: "Error in patch"
-  xios:
-      conflict:
-          # Not yet set up to run with oneapi
-          - "%oneapi"
-      require:
-          # If building everything with oneapi compile xios with intel
-          # to get compatible fortran modules
-          #
-          # Get the compiler type by matching against dependency netcdf-c
-          # If the default compiler is oneapi use intel for xios
-          # Blitz compiler must match xios
-          - one_of:
-              - "%intel ^netcdf-c%oneapi ^blitz%intel"
-              - "%intel ^netcdf-c%intel  ^blitz%intel"
-              - "%gcc   ^netcdf-c%gcc    ^blitz%gcc"
-              - "%nvhpc ^netcdf-c%nvhpc  ^blitz%nvhpc"
-  blitz:
-      # Remove the compiler constraint so it can satisfy XIOS
-      require:
-          - one_of:
-              - "%intel"
-              - "%oneapi"
-              - "%gcc"
-              - "%nvhpc"


### PR DESCRIPTION
Add support for building the lfric environment using oneapi at NCI

Currently only the gravity_wave app works, we will need to re-check compatibility once we have ifx 2025