### PR TITLE
NCI: Add gcc support, update openmpi

### DIFF
--- a/environments/lfric/etc/env.activate.sh
+++ b/environments/lfric/etc/env.activate.sh
@@ -5,7 +5,7 @@ SPACK_ENV_VIEW=$SPACK_ENV/.spack-env/view
 export FCM_KEYWORDS=${FCM_KEYWORDS:-$NGMOENVS_ENVDIR/etc/fcm-keyword.cfg}
 export LDMPI=mpifort
 export FPP="cpp -traditional"
-export FFLAGS="${FFLAGS:-} -I$SPACK_ENV_VIEW/include -I$SPACK_ENV_VIEW/lib"
+export FFLAGS="${OMPI_FCFLAGS:-} -I$SPACK_ENV_VIEW/include -I$SPACK_ENV_VIEW/lib"
 export PFUNIT=$SPACK_ENV_VIEW
 export LIBRARY_PATH=$SPACK_ENV_VIEW/lib:$LIBRARY_PATH
 

--- a/site/nci/env.sh
+++ b/site/nci/env.sh
@@ -52,6 +52,6 @@ export CONDA_BLD_PATH
 
 # Default compiler and MPI
 : "${NGMOENVS_COMPILER:="intel@2021.10.0"}"
-: "${NGMOENVS_MPI:="openmpi@4.1.5"}"
+: "${NGMOENVS_MPI:="openmpi@5.0.5"}"
 export NGMOENVS_COMPILER
 export NGMOENVS_MPI

--- a/site/nci/envrun
+++ b/site/nci/envrun
@@ -13,11 +13,8 @@ fi
 # Local FCM keyword file
 export FCM_KEYWORDS=/g/data/hr22/apps/etc/fcm/mosrs/keyword.cfg
 
-# Add central OpenMPI to cflags
-export FFLAGS="-I /apps/openmpi/5.0.5/include/Intel ${FFLAGS:-}"
-
 # Pass through LD_LIBRARY_PATH
-export SINGULARITYENV_LD_LIBRARY_PATH="/.singularity.d/libs:${LD_LIBRARY_PATH:-}"
+export SINGULARITYENV_LD_LIBRARY_PATH="/.singularity.d/libs:${LD_LIBRARY_PATH:-}:/system/lib64"
 
 # Required for oneapi sanitizers to show addresses
 export SINGULARITYENV_APPEND_PATH="/apps/intel-tools/intel-compiler-llvm/2025.0.4/bin/compiler"

--- a/site/nci/envrun
+++ b/site/nci/envrun
@@ -14,7 +14,7 @@ fi
 export FCM_KEYWORDS=/g/data/hr22/apps/etc/fcm/mosrs/keyword.cfg
 
 # Add central OpenMPI to cflags
-export FFLAGS="-I /apps/openmpi/4.1.5/include/Intel ${FFLAGS:-}"
+export FFLAGS="-I /apps/openmpi/5.0.5/include/Intel ${FFLAGS:-}"
 
 # Pass through LD_LIBRARY_PATH
 export SINGULARITYENV_LD_LIBRARY_PATH="/.singularity.d/libs:${LD_LIBRARY_PATH:-}"

--- a/site/nci/install-bare.sh
+++ b/site/nci/install-bare.sh
@@ -30,9 +30,6 @@ cat >> "$NGMOENVS_ENVDIR/bin/activate" <<EOF
 
 # Local FCM keyword file
 export FCM_KEYWORDS=/g/data/hr22/apps/etc/fcm/mosrs/keyword.cfg
-
-# Add central OpenMPI to cflags
-export FFLAGS="-I /apps/openmpi/5.0.5/include/Intel \${FFLAGS:-}"
 EOF
 
 # shellcheck source=site/nci/post-install.sh

--- a/site/nci/install-bare.sh
+++ b/site/nci/install-bare.sh
@@ -32,7 +32,7 @@ cat >> "$NGMOENVS_ENVDIR/bin/activate" <<EOF
 export FCM_KEYWORDS=/g/data/hr22/apps/etc/fcm/mosrs/keyword.cfg
 
 # Add central OpenMPI to cflags
-export FFLAGS="-I /apps/openmpi/4.1.5/include/Intel \${FFLAGS:-}"
+export FFLAGS="-I /apps/openmpi/5.0.5/include/Intel \${FFLAGS:-}"
 EOF
 
 # shellcheck source=site/nci/post-install.sh

--- a/site/nci/spack-packages.yaml
+++ b/site/nci/spack-packages.yaml
@@ -12,6 +12,7 @@ packages:
         extra_attributes:
           environment:
             set:
+              OMPI_PRTERUN: /apps/prrte/3.0.6/bin/prterun
               # Fix up the combined intel/gcc install
               OMPI_FCFLAGS: -I/apps/openmpi/5.0.5/include/Intel
               OMPI_LDFLAGS: -L/apps/openmpi/5.0.5/lib -L/apps/openmpi/5.0.5/lib/Intel -L/system/lib64 -Wl,-rpath=/apps/openmpi/5.0.5/lib -L/apps/intel-oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin -Wl,-rpath=/apps/intel-oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin
@@ -23,6 +24,7 @@ packages:
         extra_attributes:
           environment:
             set:
+              OMPI_PRTERUN: /apps/prrte/3.0.6/bin/prterun
               # Fix up the combined intel/gcc install
               OMPI_FCFLAGS: -I/apps/openmpi/5.0.5/include/Intel
               OMPI_LDFLAGS: -L/apps/openmpi/5.0.5/lib -L/apps/openmpi/5.0.5/lib/Intel -L/system/lib64 -Wl,-rpath=/apps/openmpi/5.0.5/lib
@@ -31,6 +33,7 @@ packages:
         extra_attributes:
           environment:
             set:
+              OMPI_PRTERUN: /apps/prrte/3.0.6/bin/prterun
               # Fix up the combined intel/gcc install
               OMPI_FCFLAGS: -I/apps/openmpi/5.0.5/include/GNU
               OMPI_LDFLAGS: -L/apps/openmpi/5.0.5/lib -L/apps/openmpi/5.0.5/lib/GNU -L/system/lib64 -Wl,-rpath=/apps/openmpi/5.0.5/lib

--- a/site/nci/spack-packages.yaml
+++ b/site/nci/spack-packages.yaml
@@ -40,6 +40,14 @@ packages:
             append_path:
               # Fix up runtime environment
               LD_LIBRARY_PATH: /apps/intel-oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin:/system/lib64:/lib64
+      - spec: "openmpi@5.0.5%gcc"
+        prefix: "/apps/openmpi/5.0.5"
+        extra_attributes:
+          environment:
+            set:
+              # Fix up the combined intel/gcc install
+              OMPI_FCFLAGS: -I/apps/openmpi/5.0.5/include/GNU
+              OMPI_LDFLAGS: -L/apps/openmpi/5.0.5/lib -L/apps/openmpi/5.0.5/lib/GNU -L/system/lib64 -Wl,-rpath=/apps/openmpi/5.0.5/lib
     buildable: False
   perl:
     # Getting linking errors when using shared perl libs - tries to use the system libperl.so

--- a/site/nci/spack-packages.yaml
+++ b/site/nci/spack-packages.yaml
@@ -37,6 +37,8 @@ packages:
               # Fix up the combined intel/gcc install
               OMPI_FCFLAGS: -I/apps/openmpi/5.0.5/include/GNU
               OMPI_LDFLAGS: -L/apps/openmpi/5.0.5/lib -L/apps/openmpi/5.0.5/lib/GNU -L/system/lib64 -Wl,-rpath=/apps/openmpi/5.0.5/lib
+            append_path:
+              LD_LIBRARY_PATH: /system/lib64
     buildable: False
   perl:
     # Getting linking errors when using shared perl libs - tries to use the system libperl.so

--- a/site/nci/spack-packages.yaml
+++ b/site/nci/spack-packages.yaml
@@ -7,17 +7,6 @@ packages:
     buildable: False
   openmpi:
     externals:
-      - spec: "openmpi@4.1.5%intel"
-        prefix: "/apps/openmpi/4.1.5"
-        extra_attributes:
-          environment:
-            set:
-              # Fix up the combined intel/gcc install
-              OMPI_FCFLAGS: -I/apps/openmpi/4.1.5/include/Intel
-              OMPI_LDFLAGS: -L/apps/openmpi/4.1.5/lib -L/apps/openmpi/4.1.5/lib/Intel -L/system/lib64 -Wl,-rpath=/apps/openmpi/4.1.5/lib -L/apps/intel-oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin -Wl,-rpath=/apps/intel-oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin
-            append_path:
-              # Fix up runtime environment
-                LD_LIBRARY_PATH: /apps/intel-oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin:/system/lib64:/lib64
       - spec: "openmpi@5.0.5%intel"
         prefix: "/apps/openmpi/5.0.5"
         extra_attributes:
@@ -29,17 +18,14 @@ packages:
             append_path:
               # Fix up runtime environment
               LD_LIBRARY_PATH: /apps/intel-oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin:/system/lib64:/lib64
-      - spec: "openmpi@4.1.5%oneapi"
-        prefix: "/apps/openmpi/4.1.5"
+      - spec: "openmpi@5.0.5%oneapi"
+        prefix: "/apps/openmpi/5.0.5"
         extra_attributes:
           environment:
             set:
               # Fix up the combined intel/gcc install
-              OMPI_FCFLAGS: -I/apps/openmpi/4.1.5/include/Intel
-              OMPI_LDFLAGS: -L/apps/openmpi/4.1.5/lib -L/apps/openmpi/4.1.5/lib/Intel -L/system/lib64 -Wl,-rpath=/apps/openmpi/4.1.5/lib -L/apps/intel-oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin -Wl,-rpath=/apps/intel-oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin
-            append_path:
-              # Fix up runtime environment
-              LD_LIBRARY_PATH: /apps/intel-oneapi/compiler/2023.2.0/linux/compiler/lib/intel64_lin:/system/lib64:/lib64
+              OMPI_FCFLAGS: -I/apps/openmpi/5.0.5/include/Intel
+              OMPI_LDFLAGS: -L/apps/openmpi/5.0.5/lib -L/apps/openmpi/5.0.5/lib/Intel -L/system/lib64 -Wl,-rpath=/apps/openmpi/5.0.5/lib
       - spec: "openmpi@5.0.5%gcc"
         prefix: "/apps/openmpi/5.0.5"
         extra_attributes:

--- a/spack/packages/yaxt/package.py
+++ b/spack/packages/yaxt/package.py
@@ -17,8 +17,9 @@ class Yaxt(AutotoolsPackage):
     depends_on('mpi')
     variant('idxtype', default='int', values=('int','long'), multi=False)
 
-    # Doesn't work for gcc
-    parallel = False
+    # Parallel build not working with GCC
+    with when("%gcc"):
+        parallel = False
 
     def setup_build_environment(self, env):
         env.set('CC', self.spec['mpi'].mpicc)

--- a/spack/packages/yaxt/package.py
+++ b/spack/packages/yaxt/package.py
@@ -17,6 +17,9 @@ class Yaxt(AutotoolsPackage):
     depends_on('mpi')
     variant('idxtype', default='int', values=('int','long'), multi=False)
 
+    # Doesn't work for gcc
+    parallel = False
+
     def setup_build_environment(self, env):
         env.set('CC', self.spec['mpi'].mpicc)
         env.set('CXX', self.spec['mpi'].mpicxx)


### PR DESCRIPTION
Allow building with gcc compiler

Update openmpi to 5.0.5 

Fixes #17